### PR TITLE
/uri/{uri}/descendants - returns all descendants

### DIFF
--- a/phis2-ws/src/main/java/phis2ws/service/configuration/URINamespaces.java
+++ b/phis2-ws/src/main/java/phis2ws/service/configuration/URINamespaces.java
@@ -171,7 +171,7 @@ public class URINamespaces {
         
         //Relations rdfs
         RELATIONS.put("subClassOf","rdfs:subClassOf");
-        RELATIONS.put("subClassOf*","rdfs:subClassOf");
+        RELATIONS.put("subClassOf*","rdfs:subClassOf*");
         RELATIONS.put("label", "rdfs:label");
         RELATIONS.put("type", "rdf:type");
     }


### PR DESCRIPTION
The service /uri/{uri}/descendants returned only direct descendants (children). It now returns all the descendants