### PR TITLE
Add mongo transaction for environment data insertion

### DIFF
--- a/phis2-ws/pom.xml
+++ b/phis2-ws/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
-            <version>3.5.0</version>
+            <version>3.9.0</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
WARNING: 
This feature need at least MongoDB v4.0 which require to use a newer version of the driver
Update mongodb-driver in pom.xml to v3.9.0
@see https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#java-driver-compatibility

This feature need also to have an instance of mongo which is a replica set
@see https://docs.mongodb.com/manual/core/transactions/#transactions-and-replica-sets
@see https://docs.mongodb.com/manual/tutorial/convert-standalone-to-replica-set/