### PR TITLE
Image/upload folder issue

### DIFF
--- a/phis2-ws/src/main/java/phis2ws/service/resources/ImageResourceService.java
+++ b/phis2-ws/src/main/java/phis2ws/service/resources/ImageResourceService.java
@@ -202,7 +202,7 @@ public class ImageResourceService extends ResourceService {
      */
     private String getServerImagesDirectory() {
         return PropertiesFileManager.getConfigFileProperty("service", "uploadImageServerDirectory") + "/"
-                + PropertiesFileManager.getConfigFileProperty("sesame_rdf_config", "platform") + "/" 
+                + PropertiesFileManager.getConfigFileProperty("sesame_rdf_config", "infrastructure") + "/" 
                 + Year.now().toString();
     }
     
@@ -213,7 +213,7 @@ public class ImageResourceService extends ResourceService {
      */
     private String getWebAccessImagesDirectory() {
         return PropertiesFileManager.getConfigFileProperty("service", "imageFileServerDirectory") + "/"
-                + PropertiesFileManager.getConfigFileProperty("sesame_rdf_config", "platform") + "/" 
+                + PropertiesFileManager.getConfigFileProperty("sesame_rdf_config", "infrastructure") + "/" 
                 + Year.now().toString();
     }
     

--- a/phis2-ws/src/main/java/phis2ws/service/resources/ImageResourceService.java
+++ b/phis2-ws/src/main/java/phis2ws/service/resources/ImageResourceService.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.logging.Level;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
@@ -288,7 +289,7 @@ public class ImageResourceService extends ResourceService {
         final String serverFileName = getImageName(imageUri) + "." + WAITING_METADATA_INFORMATION.get(imageUri).getFileInformations().getExtension();
         final String serverImagesDirectory = getServerImagesDirectory();
         final String webAccessImagesDirectory = getWebAccessImagesDirectory();
-        
+    
         try {
             WAITING_METADATA_FILE_CHECK.put(imageUri, Boolean.TRUE);
             //SILEX:test
@@ -297,7 +298,7 @@ public class ImageResourceService extends ResourceService {
         } catch (SftpException e) {
             try {
                 //Create repository if it does not exist
-                jsch.getChannelSftp().mkdir(serverImagesDirectory);
+                jsch.createNestedDirectories(serverImagesDirectory);
                 jsch.getChannelSftp().cd(serverImagesDirectory);
                 LOGGER.debug("Create directory : " + serverImagesDirectory);
             } catch (SftpException ex) {

--- a/phis2-ws/src/main/java/phis2ws/service/utils/FileUploader.java
+++ b/phis2-ws/src/main/java/phis2ws/service/utils/FileUploader.java
@@ -1,12 +1,11 @@
 //**********************************************************************************************
 //                                       FileUploader.java 
-//
 // Author(s): Arnaud Charleroy 
-// PHIS-SILEX version 1.0
-// Copyright © - INRA - 2016
-// Creation date: may 2016
-// Contact:arnaud.charleroy@inra.fr, anne.tireau@inra.fr, pascal.neveu@inra.fr
-// Last modification date:  October, 2016
+// PHIS-SILEX
+// Copyright © INRA 2016
+// Creation date: May 2016
+// Contact: arnaud.charleroy@inra.fr, anne.tireau@inra.fr, pascal.neveu@inra.fr
+// Last modification date:  Jan., 2019
 // Subject: A class which permit to send a file to a distant server
 //***********************************************************************************************
 package phis2ws.service.utils;
@@ -29,6 +28,8 @@ import phis2ws.service.PropertiesFileManager;
 /**
  * Classe qui étends la libraire JSch qui permet de réaliser des appels en SFTP en Java de façon siplifiée.
  * @author Arnaud Charleroy
+ * @update [Andréas Garcia] 23 Jan., 2019 : Add generic function to create nested 
+ * directories from a complete path
  */
 public class FileUploader extends JSch{
     final static Logger LOGGER = LoggerFactory.getLogger(FileUploader.class);
@@ -91,6 +92,39 @@ public class FileUploader extends JSch{
         
         return true;
     }
+    
+    /**
+     * Create nested directories from a given path.
+     * The mkdir function of thet ChannelSftp object can only create one 
+     * directory in the current folder. If a path with several folders is given, 
+     * an exception is thrown.
+     * So we have to mannually implement the behaviour desired.
+     * @param nestedDirectoriesPath
+     * @throws SftpException 
+     */
+    public void createNestedDirectories(String nestedDirectoriesPath) throws SftpException {
+        ChannelSftp channelTarget = getChannelSftp();
+        
+        // Split the complete path into a list of folders
+        String[] directories = nestedDirectoriesPath.split("/");
+        channelTarget.cd("/");
+        for (String directory : directories) {
+            if (directory.length() > 0) {
+                try {
+                    channelTarget.cd(directory);
+                } catch (SftpException e2) {
+                    // If the folder doesn't exist, create it and go into
+                    channelTarget.mkdir(directory);
+                    channelTarget.cd(directory);
+                }
+            }
+        }
+        // Go back to the original folder
+        for (String directory : directories) {
+            channelTarget.cd("..");
+        }
+    }
+    
     /**
      * Fermeture des ressources
      */


### PR DESCRIPTION
When uploading an image in a platform for the first time, the WS has to generate 2 nested folders in images/ which are in the {platform}/{year} pattern. This creation didn't work well : the folders were not created and the generated path of the uploaded image contained a "null" folder.

This PR aims at :
- getting rightly the current platform name which is part of the path of the uploaded images
- creating without error the eventual nested folders