### PR TITLE
Change the dev config file to fit the local install documentation 

### DIFF
--- a/phis2-ws/src/main/profiles/dev/config.properties
+++ b/phis2-ws/src/main/profiles/dev/config.properties
@@ -34,7 +34,7 @@ ws.doc.name=phis2ws
 ws.updir.host=localhost
 ws.updir.user=username
 ws.updir.password=password
-ws.updir.doc=~/opensilex/documents/instance
+ws.updir.doc=/home/<username>/opensilex/documents/instance
 
 ws.images.dir=/var/www/html/images
 ws.images.url=http://localhost/images

--- a/phis2-ws/src/main/profiles/dev/config.properties
+++ b/phis2-ws/src/main/profiles/dev/config.properties
@@ -20,7 +20,7 @@ rdf.repo=repository
 rdf.vocabulary.context=http://www.opensilex.org/vocabulary/oeso
 
 # Webservice configuration
-ws.log.dir=/home/tomcat/phis2ws/logs
+ws.log.dir=/home/tomcat/apache-tomcat/logs/opensilex-ws
 
 ws.host=localhost
 ws.port=8084

--- a/phis2-ws/src/main/profiles/dev/config.properties
+++ b/phis2-ws/src/main/profiles/dev/config.properties
@@ -34,7 +34,7 @@ ws.doc.name=phis2ws
 ws.updir.host=localhost
 ws.updir.user=username
 ws.updir.password=password
-ws.updir.doc=/home/phis2ws/documents/instance
+ws.updir.doc=~opensilexws/documents/instance
 
 ws.images.dir=/var/www/html/images
 ws.images.url=http://localhost/images

--- a/phis2-ws/src/main/profiles/dev/config.properties
+++ b/phis2-ws/src/main/profiles/dev/config.properties
@@ -34,7 +34,7 @@ ws.doc.name=phis2ws
 ws.updir.host=localhost
 ws.updir.user=username
 ws.updir.password=password
-ws.updir.doc=~opensilexws/documents/instance
+ws.updir.doc=~/opensilex/documents/instance
 
 ws.images.dir=/var/www/html/images
 ws.images.url=http://localhost/images


### PR DESCRIPTION
In the dev config file :
 - change paths to fit documentation
 - replace "~" by full paths because it may be misintepreted in Java