### PR TITLE
DAOs - Handle query exceptions in generic functions

### DIFF
--- a/phis2-ws/src/main/java/opensilex/service/dao/exception/DAODataErrorException.java
+++ b/phis2-ws/src/main/java/opensilex/service/dao/exception/DAODataErrorException.java
@@ -11,7 +11,7 @@ package opensilex.service.dao.exception;
  * Exception thrown by a DAO when detecting a data error.
  * @author Andréas Garcia <andreas.garcia@inra.fr>
  */
-public abstract class DAODataErrorException extends Exception {
+public abstract class DAODataErrorException extends DAOException {
     public static String GENERIC_MESSAGE = "A DAO issue occured";
     
     public DAODataErrorException() {
@@ -29,6 +29,4 @@ public abstract class DAODataErrorException extends Exception {
     public DAODataErrorException(String message, Throwable throwableCause) {
         super(message, throwableCause);
     }
-    
-    public abstract String getGenericMessage();
 }

--- a/phis2-ws/src/main/java/opensilex/service/dao/exception/DAOException.java
+++ b/phis2-ws/src/main/java/opensilex/service/dao/exception/DAOException.java
@@ -1,0 +1,37 @@
+//******************************************************************************
+//                               DAOException.java
+// SILEX-PHIS
+// Copyright © INRA 2019
+// Creation date: 10 Apr. 2019
+// Contact: andreas.garcia@inra.fr, anne.tireau@inra.fr, pascal.neveu@inra.fr
+//******************************************************************************
+package opensilex.service.dao.exception;
+
+/**
+ * Abstract exception thrown during a DAO operation.
+ * @author Andréas Garcia <andreas.garcia@inra.fr>
+ */
+public abstract class DAOException extends Exception {
+    
+    public final static String GENERIC_MESSAGE = "An error occured during a DAO operation.";
+    
+    public DAOException() {
+        super(GENERIC_MESSAGE);
+    }
+    
+    public DAOException(Throwable throwableCause) {
+        super(GENERIC_MESSAGE, throwableCause);
+    }
+    
+    public DAOException(String errorMessage) {
+        super(errorMessage);
+    }
+    
+    public DAOException(String message, Throwable throwableCause) {
+        super(message, throwableCause);
+    }
+
+    public String getGenericMessage() {
+        return GENERIC_MESSAGE;
+    }
+}

--- a/phis2-ws/src/main/java/opensilex/service/dao/exception/DAOPersistenceException.java
+++ b/phis2-ws/src/main/java/opensilex/service/dao/exception/DAOPersistenceException.java
@@ -1,0 +1,37 @@
+//******************************************************************************
+//                         DAOPersistenceException.java
+// SILEX-PHIS
+// Copyright © INRA 2019
+// Creation date: 15 Apr. 2019
+// Contact: andreas.garcia@inra.fr, anne.tireau@inra.fr, pascal.neveu@inra.fr
+//******************************************************************************
+package opensilex.service.dao.exception;
+
+/**
+ * A persistence exception occured during a DAO operation.
+ * @author Andréas Garcia <andreas.garcia@inra.fr>
+ */
+public class DAOPersistenceException extends DAOException {
+    public static String GENERIC_MESSAGE = "An error occured during an operation in the data persistence system.";
+    
+    public DAOPersistenceException() {
+        super(GENERIC_MESSAGE);
+    }
+    
+    public DAOPersistenceException(Throwable throwableCause) {
+        super(GENERIC_MESSAGE, throwableCause);
+    }
+    
+    public DAOPersistenceException(String message) {
+        super(message);
+    }
+    
+    public DAOPersistenceException(String message, Throwable throwableCause) {
+        super(message, throwableCause);
+    }
+
+    @Override
+    public String getGenericMessage() {
+        return GENERIC_MESSAGE;
+    }
+}

--- a/phis2-ws/src/main/java/phis2ws/service/dao/manager/DAO.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/manager/DAO.java
@@ -9,6 +9,7 @@ package phis2ws.service.dao.manager;
 
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import opensilex.service.dao.exception.ResourceAccessDeniedException;
 import phis2ws.service.model.User;
 
@@ -29,59 +30,66 @@ public abstract class DAO<T> {
      * Creates in the storage the list of objects given.
      * @param objects
      * @return the given list with the generated IDs 
+     * @throws opensilex.service.dao.exception.DAOPersistenceException 
      * @throws java.lang.Exception
      */
-    public abstract List<T> create(List<T> objects) throws Exception;
+    public abstract List<T> create(List<T> objects) throws DAOPersistenceException, Exception;
 
     /**
      * Deletes in the storage the list of objects given.
      * @param objects
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws java.lang.Exception
      */
-    public abstract void delete(List<T> objects) throws Exception;
+    public abstract void delete(List<T> objects) throws DAOPersistenceException, Exception;
 
     /**
      * Updates in the storage the list of objects given.
      * @param objects
      * @return the given list with the data updated
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws java.lang.Exception
      */
-    public abstract List<T> update(List<T> objects) throws Exception;
+    public abstract List<T> update(List<T> objects) throws DAOPersistenceException, Exception;
 
     /**
      * Finds in the storage the object given.
      * @param object
      * @return the object found
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws java.lang.Exception
      */
-    public abstract T find(T object) throws Exception;
+    public abstract T find(T object) throws DAOPersistenceException, Exception;
 
     /**
      * Finds in the storage the objects with the ID given.
      * @param id
      * @return the object found
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws java.lang.Exception
      */
-    public abstract T findById(String id) throws Exception;
+    public abstract T findById(String id) throws DAOPersistenceException, Exception;
     
     /**
      * Validates the objects given.
      * @param objects
      * @throws DAODataErrorAggregateException to handle multiple data error exceptions.
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws opensilex.service.dao.exception.ResourceAccessDeniedException 
      */
     public abstract void validate(List<T> objects) 
-            throws DAODataErrorAggregateException, ResourceAccessDeniedException;
+            throws DAOPersistenceException, DAODataErrorAggregateException, DAOPersistenceException, ResourceAccessDeniedException;
     
     /**
      * Validates and creates objects.
      * @param objects
      * @return the annotations created.
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws opensilex.service.dao.exception.DAODataErrorAggregateException
      * @throws opensilex.service.dao.exception.ResourceAccessDeniedException
      */
     public List<T> validateAndCreate(List<T> objects) 
-            throws DAODataErrorAggregateException, ResourceAccessDeniedException, Exception {
+            throws DAOPersistenceException, DAODataErrorAggregateException, ResourceAccessDeniedException, Exception {
         validate(objects);     
         initConnection();
         List<T> objectsCreated;
@@ -100,11 +108,12 @@ public abstract class DAO<T> {
      * Validates and updates objects.
      * @param objects
      * @return the objects created.
+     * @throws opensilex.service.dao.exception.DAOPersistenceException
      * @throws opensilex.service.dao.exception.DAODataErrorAggregateException
      * @throws opensilex.service.dao.exception.ResourceAccessDeniedException
      */
     public List<T> validateAndUpdate(List<T> objects) 
-            throws DAODataErrorAggregateException, ResourceAccessDeniedException, Exception {
+            throws DAOPersistenceException, DAODataErrorAggregateException, ResourceAccessDeniedException, Exception {
         validate(objects);     
         initConnection();
         List<T> objectsUpdated;

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DataDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DataDAOMongo.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
+import opensilex.service.dao.exception.ResourceAccessDeniedException;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
@@ -418,32 +420,32 @@ public class DataDAOMongo extends DAOMongo<Data> {
     }
 
     @Override
-    public List<Data> create(List<Data> objects) throws Exception {
+    public List<Data> create(List<Data> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Data> objects) throws Exception {
+    public void delete(List<Data> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Data> update(List<Data> objects) throws Exception {
+    public List<Data> update(List<Data> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Data find(Data object) throws Exception {
+    public Data find(Data object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Data findById(String id) throws Exception {
+    public Data findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Data> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Data> objects) throws DAOPersistenceException, DAODataErrorAggregateException, DAOPersistenceException, ResourceAccessDeniedException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DataFileDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DataFileDAOMongo.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.List;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.BSONObject;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -478,32 +479,32 @@ public class DataFileDAOMongo extends DAOMongo<FileDescription> {
     }
 
     @Override
-    public List<FileDescription> create(List<FileDescription> objects) throws Exception {
+    public List<FileDescription> create(List<FileDescription> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<FileDescription> objects) throws Exception {
+    public void delete(List<FileDescription> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<FileDescription> update(List<FileDescription> objects) throws Exception {
+    public List<FileDescription> update(List<FileDescription> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public FileDescription find(FileDescription object) throws Exception {
+    public FileDescription find(FileDescription object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public FileDescription findById(String id) throws Exception {
+    public FileDescription findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<FileDescription> objects) throws DAODataErrorAggregateException {
+    public void validate(List<FileDescription> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DatasetDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DatasetDAOMongo.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -395,32 +396,32 @@ public class DatasetDAOMongo extends DAOMongo<Dataset> {
     }
 
     @Override
-    public List<Dataset> create(List<Dataset> objects) throws Exception {
+    public List<Dataset> create(List<Dataset> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Dataset> objects) throws Exception {
+    public void delete(List<Dataset> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Dataset> update(List<Dataset> objects) throws Exception {
+    public List<Dataset> update(List<Dataset> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Dataset find(Dataset object) throws Exception {
+    public Dataset find(Dataset object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Dataset findById(String id) throws Exception {
+    public Dataset findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Dataset> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Dataset> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DocumentDaoMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/DocumentDaoMongo.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.commons.io.IOUtils;
 import phis2ws.service.PropertiesFileManager;
 import phis2ws.service.dao.manager.DAOMongo;
@@ -91,32 +92,32 @@ public class DocumentDaoMongo extends DAOMongo<Document> {
     }
 
     @Override
-    public List<Document> create(List<Document> objects) throws Exception {
+    public List<Document> create(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Document> objects) throws Exception {
+    public void delete(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Document> update(List<Document> objects) throws Exception {
+    public List<Document> update(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Document find(Document object) throws Exception {
+    public Document find(Document object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Document findById(String id) throws Exception {
+    public Document findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Document> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Document> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/EnvironmentDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/EnvironmentDAOMongo.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
@@ -402,32 +403,32 @@ public class EnvironmentDAOMongo extends DAOMongo<EnvironmentMeasure> {
     }
 
     @Override
-    public List<EnvironmentMeasure> create(List<EnvironmentMeasure> objects) throws Exception {
+    public List<EnvironmentMeasure> create(List<EnvironmentMeasure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<EnvironmentMeasure> objects) throws Exception {
+    public void delete(List<EnvironmentMeasure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<EnvironmentMeasure> update(List<EnvironmentMeasure> objects) throws Exception {
+    public List<EnvironmentMeasure> update(List<EnvironmentMeasure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public EnvironmentMeasure find(EnvironmentMeasure object) throws Exception {
+    public EnvironmentMeasure find(EnvironmentMeasure object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public EnvironmentMeasure findById(String id) throws Exception {
+    public EnvironmentMeasure findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<EnvironmentMeasure> objects) throws DAODataErrorAggregateException {
+    public void validate(List<EnvironmentMeasure> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/FileInformationsDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/FileInformationsDAOMongo.java
@@ -11,6 +11,7 @@ import com.mongodb.BasicDBObject;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,32 +55,32 @@ public class FileInformationsDAOMongo extends DAOMongo<FileInformations> {
     }
 
     @Override
-    public List<FileInformations> create(List<FileInformations> objects) throws Exception {
+    public List<FileInformations> create(List<FileInformations> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<FileInformations> objects) throws Exception {
+    public void delete(List<FileInformations> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<FileInformations> update(List<FileInformations> objects) throws Exception {
+    public List<FileInformations> update(List<FileInformations> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public FileInformations find(FileInformations object) throws Exception {
+    public FileInformations find(FileInformations object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public FileInformations findById(String id) throws Exception {
+    public FileInformations findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<FileInformations> objects) throws DAODataErrorAggregateException {
+    public void validate(List<FileInformations> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ImageMetadataDaoMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ImageMetadataDaoMongo.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -348,32 +349,32 @@ public class ImageMetadataDaoMongo extends DAOMongo<ImageMetadata> {
     }
 
     @Override
-    public List<ImageMetadata> create(List<ImageMetadata> objects) throws Exception {
+    public List<ImageMetadata> create(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ImageMetadata> objects) throws Exception {
+    public void delete(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ImageMetadata> update(List<ImageMetadata> objects) throws Exception {
+    public List<ImageMetadata> update(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ImageMetadata find(ImageMetadata object) throws Exception {
+    public ImageMetadata find(ImageMetadata object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ImageMetadata findById(String id) throws Exception {
+    public ImageMetadata findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ImageMetadata> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ImageMetadata> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ProvenanceDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ProvenanceDAOMongo.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.BSONObject;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -429,32 +430,32 @@ public class ProvenanceDAOMongo extends DAOMongo<Provenance> {
     }
 
     @Override
-    public List<Provenance> create(List<Provenance> objects) throws Exception {
+    public List<Provenance> create(List<Provenance> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Provenance> objects) throws Exception {
+    public void delete(List<Provenance> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Provenance find(Provenance object) throws Exception {
+    public Provenance find(Provenance object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Provenance findById(String id) throws Exception {
+    public Provenance findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Provenance> update(List<Provenance> objects) throws Exception {
+    public List<Provenance> update(List<Provenance> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Provenance> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Provenance> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ShootingConfigurationDAOMongo.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/mongo/ShootingConfigurationDAOMongo.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,32 +60,32 @@ public class ShootingConfigurationDAOMongo extends DAOMongo<ShootingConfiguratio
     }
 
     @Override
-    public List<ShootingConfiguration> create(List<ShootingConfiguration> objects) throws Exception {
+    public List<ShootingConfiguration> create(List<ShootingConfiguration> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ShootingConfiguration> objects) throws Exception {
+    public void delete(List<ShootingConfiguration> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ShootingConfiguration> update(List<ShootingConfiguration> objects) throws Exception {
+    public List<ShootingConfiguration> update(List<ShootingConfiguration> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ShootingConfiguration find(ShootingConfiguration object) throws Exception {
+    public ShootingConfiguration find(ShootingConfiguration object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ShootingConfiguration findById(String id) throws Exception {
+    public ShootingConfiguration findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ShootingConfiguration> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ShootingConfiguration> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/ExperimentDao.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/ExperimentDao.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1218,27 +1219,27 @@ public class ExperimentDao extends DAOPhisBrapi<Experiment, ExperimentDTO> {
     }
 
     @Override
-    public List<Experiment> create(List<Experiment> objects) throws Exception {
+    public List<Experiment> create(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Experiment> objects) throws Exception {
+    public void delete(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Experiment> update(List<Experiment> objects) throws Exception {
+    public List<Experiment> update(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Experiment findById(String id) throws Exception {
+    public Experiment findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Experiment> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Experiment> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/GroupDao.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/GroupDao.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.sparql.AlreadyExists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -573,27 +574,27 @@ public class GroupDao extends DAOPhisBrapi<Group, GroupDTO> {
     }
 
     @Override
-    public List<Group> create(List<Group> objects) throws Exception {
+    public List<Group> create(List<Group> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Group> objects) throws Exception {
+    public void delete(List<Group> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Group> update(List<Group> objects) throws Exception {
+    public List<Group> update(List<Group> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Group findById(String id) throws Exception {
+    public Group findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Group> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Group> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/LayerDao.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/LayerDao.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import phis2ws.service.PropertiesFileManager;
@@ -227,32 +228,32 @@ public class LayerDao extends DAO<LayerDTO>{
     }
 
     @Override
-    public List<LayerDTO> create(List<LayerDTO> objects) throws Exception {
+    public List<LayerDTO> create(List<LayerDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<LayerDTO> objects) throws Exception {
+    public void delete(List<LayerDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<LayerDTO> update(List<LayerDTO> objects) throws Exception {
+    public List<LayerDTO> update(List<LayerDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public LayerDTO find(LayerDTO object) throws Exception {
+    public LayerDTO find(LayerDTO object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public LayerDTO findById(String id) throws Exception {
+    public LayerDTO findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<LayerDTO> objects) throws DAODataErrorAggregateException {
+    public void validate(List<LayerDTO> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/ProjectDao.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/ProjectDao.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.sparql.AlreadyExists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -623,27 +624,27 @@ public class ProjectDao extends DAOPhisBrapi<Project, ProjectDTO> {
     }
 
     @Override
-    public List<Project> create(List<Project> objects) throws Exception {
+    public List<Project> create(List<Project> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Project> objects) throws Exception {
+    public void delete(List<Project> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Project> update(List<Project> objects) throws Exception {
+    public List<Project> update(List<Project> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Project findById(String id) throws Exception {
+    public Project findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Project> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Project> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/ScientificObjectDAO.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/ScientificObjectDAO.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import phis2ws.service.dao.manager.DAOPhisBrapi;
@@ -322,27 +323,27 @@ public class ScientificObjectDAO extends DAOPhisBrapi<ScientificObject, Scientif
     }
 
     @Override
-    public List<ScientificObject> create(List<ScientificObject> objects) throws Exception {
+    public List<ScientificObject> create(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ScientificObject> objects) throws Exception {
+    public void delete(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ScientificObject> update(List<ScientificObject> objects) throws Exception {
+    public List<ScientificObject> update(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ScientificObject findById(String id) throws Exception {
+    public ScientificObject findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ScientificObject> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ScientificObject> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/SessionDaoPhisBrapi.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/SessionDaoPhisBrapi.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import phis2ws.service.dao.manager.DAOPhisBrapi;
@@ -228,27 +229,27 @@ public class SessionDaoPhisBrapi extends DAOPhisBrapi<Session, Object> {
     }
 
     @Override
-    public List<Session> create(List<Session> objects) throws Exception {
+    public List<Session> create(List<Session> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Session> objects) throws Exception {
+    public void delete(List<Session> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Session> update(List<Session> objects) throws Exception {
+    public List<Session> update(List<Session> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Session findById(String id) throws Exception {
+    public Session findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Session> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Session> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 } 

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/StudyDAO.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/StudyDAO.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import phis2ws.service.dao.manager.DAO;
@@ -248,32 +249,32 @@ public class StudyDAO extends DAO<StudyDetails>{
     }
 
     @Override
-    public List<StudyDetails> create(List<StudyDetails> objects) throws Exception {
+    public List<StudyDetails> create(List<StudyDetails> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<StudyDetails> objects) throws Exception {
+    public void delete(List<StudyDetails> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<StudyDetails> update(List<StudyDetails> objects) throws Exception {
+    public List<StudyDetails> update(List<StudyDetails> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public StudyDetails find(StudyDetails object) throws Exception {
+    public StudyDetails find(StudyDetails object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public StudyDetails findById(String id) throws Exception {
+    public StudyDetails findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<StudyDetails> objects) throws DAODataErrorAggregateException {
+    public void validate(List<StudyDetails> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/phis2-ws/src/main/java/phis2ws/service/dao/phis/UserDaoPhisBrapi.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/phis/UserDaoPhisBrapi.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import javax.ws.rs.core.Response;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import phis2ws.service.dao.manager.DAOPhisBrapi;
@@ -883,27 +884,27 @@ public class UserDaoPhisBrapi extends DAOPhisBrapi<User, UserDTO> {
     }
 
     @Override
-    public List<User> create(List<User> objects) throws Exception {
+    public List<User> create(List<User> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<User> objects) throws Exception {
+    public void delete(List<User> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<User> update(List<User> objects) throws Exception {
+    public List<User> update(List<User> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public User findById(String id) throws Exception {
+    public User findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<User> objects) throws DAODataErrorAggregateException {
+    public void validate(List<User> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/AcquisitionSessionDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/AcquisitionSessionDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -262,7 +263,7 @@ public class AcquisitionSessionDAOSesame extends DAOSesame<MetadataFileDTO> {
     }
 
     @Override
-    public void validate(List<MetadataFileDTO> objects) throws DAODataErrorAggregateException {
+    public void validate(List<MetadataFileDTO> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/AnnotationDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/AnnotationDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
@@ -468,32 +469,32 @@ public class AnnotationDAOSesame extends DAOSesame<Annotation> {
     }
 
     @Override
-    public List<Annotation> create(List<Annotation> objects) throws Exception {
+    public List<Annotation> create(List<Annotation> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Annotation> objects) throws Exception {
+    public void delete(List<Annotation> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Annotation> update(List<Annotation> objects) throws Exception {
+    public List<Annotation> update(List<Annotation> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Annotation find(Annotation object) throws Exception {
+    public Annotation find(Annotation object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Annotation findById(String id) throws Exception {
+    public Annotation findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Annotation> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Annotation> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ConcernedItemDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ConcernedItemDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -324,32 +325,32 @@ public class ConcernedItemDAOSesame extends DAOSesame<ConcernedItem> {
     }
 
     @Override
-    public List<ConcernedItem> create(List<ConcernedItem> objects) throws Exception {
+    public List<ConcernedItem> create(List<ConcernedItem> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ConcernedItem> objects) throws Exception {
+    public void delete(List<ConcernedItem> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ConcernedItem> update(List<ConcernedItem> objects) throws Exception {
+    public List<ConcernedItem> update(List<ConcernedItem> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ConcernedItem find(ConcernedItem object) throws Exception {
+    public ConcernedItem find(ConcernedItem object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ConcernedItem findById(String id) throws Exception {
+    public ConcernedItem findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ConcernedItem> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ConcernedItem> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/DocumentDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/DocumentDaoSesame.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -823,32 +824,32 @@ public class DocumentDaoSesame extends DAOSesame<Document> {
     }
 
     @Override
-    public List<Document> create(List<Document> objects) throws Exception {
+    public List<Document> create(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Document> objects) throws Exception {
+    public void delete(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Document> update(List<Document> objects) throws Exception {
+    public List<Document> update(List<Document> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Document find(Document object) throws Exception {
+    public Document find(Document object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Document findById(String id) throws Exception {
+    public Document findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Document> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Document> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/EventDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/EventDAOSesame.java
@@ -10,6 +10,7 @@ package phis2ws.service.dao.sesame;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -607,32 +608,32 @@ public class EventDAOSesame extends DAOSesame<Event> {
     }
 
     @Override
-    public List<Event> create(List<Event> objects) throws Exception {
+    public List<Event> create(List<Event> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Event> objects) throws Exception {
+    public void delete(List<Event> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Event> update(List<Event> objects) throws Exception {
+    public List<Event> update(List<Event> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Event find(Event object) throws Exception {
+    public Event find(Event object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Event findById(String id) throws Exception {
+    public Event findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Event> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Event> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ExperimentDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ExperimentDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -405,32 +406,32 @@ public class ExperimentDAOSesame extends DAOSesame<Experiment> {
     }
 
     @Override
-    public List<Experiment> create(List<Experiment> objects) throws Exception {
+    public List<Experiment> create(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Experiment> objects) throws Exception {
+    public void delete(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Experiment> update(List<Experiment> objects) throws Exception {
+    public List<Experiment> update(List<Experiment> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Experiment find(Experiment object) throws Exception {
+    public Experiment find(Experiment object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Experiment findById(String id) throws Exception {
+    public Experiment findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Experiment> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Experiment> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ImageMetadataDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ImageMetadataDaoSesame.java
@@ -13,6 +13,7 @@ package phis2ws.service.dao.sesame;
 
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -36,32 +37,32 @@ public class ImageMetadataDaoSesame extends DAOSesame<ImageMetadata> {
     }
 
     @Override
-    public List<ImageMetadata> create(List<ImageMetadata> objects) throws Exception {
+    public List<ImageMetadata> create(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ImageMetadata> objects) throws Exception {
+    public void delete(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ImageMetadata> update(List<ImageMetadata> objects) throws Exception {
+    public List<ImageMetadata> update(List<ImageMetadata> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ImageMetadata find(ImageMetadata object) throws Exception {
+    public ImageMetadata find(ImageMetadata object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ImageMetadata findById(String id) throws Exception {
+    public ImageMetadata findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ImageMetadata> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ImageMetadata> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/InfrastructureDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/InfrastructureDAOSesame.java
@@ -11,6 +11,7 @@ package phis2ws.service.dao.sesame;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -214,32 +215,32 @@ public class InfrastructureDAOSesame extends DAOSesame<Infrastructure> {
     }
 
     @Override
-    public List<Infrastructure> create(List<Infrastructure> objects) throws Exception {
+    public List<Infrastructure> create(List<Infrastructure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Infrastructure> objects) throws Exception {
+    public void delete(List<Infrastructure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Infrastructure> update(List<Infrastructure> objects) throws Exception {
+    public List<Infrastructure> update(List<Infrastructure> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Infrastructure find(Infrastructure object) throws Exception {
+    public Infrastructure find(Infrastructure object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Infrastructure findById(String id) throws Exception {
+    public Infrastructure findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Infrastructure> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Infrastructure> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/MethodDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/MethodDaoSesame.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -497,32 +498,32 @@ public class MethodDaoSesame extends DAOSesame<Method> {
     }
 
     @Override
-    public List<Method> create(List<Method> objects) throws Exception {
+    public List<Method> create(List<Method> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Method> objects) throws Exception {
+    public void delete(List<Method> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Method> update(List<Method> objects) throws Exception {
+    public List<Method> update(List<Method> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Method find(Method object) throws Exception {
+    public Method find(Method object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Method findById(String id) throws Exception {
+    public Method findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Method> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Method> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/PropertyDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/PropertyDAOSesame.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -975,32 +976,32 @@ public class PropertyDAOSesame extends DAOSesame<Property> {
     }
 
     @Override
-    public List<Property> create(List<Property> objects) throws Exception {
+    public List<Property> create(List<Property> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Property> objects) throws Exception {
+    public void delete(List<Property> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Property> update(List<Property> objects) throws Exception {
+    public List<Property> update(List<Property> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Property find(Property object) throws Exception {
+    public Property find(Property object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Property findById(String id) throws Exception {
+    public Property findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Property> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Property> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/RadiometricTargetDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/RadiometricTargetDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -637,32 +638,32 @@ public class RadiometricTargetDAOSesame extends DAOSesame<RadiometricTarget> {
     }
 
     @Override
-    public List<RadiometricTarget> create(List<RadiometricTarget> objects) throws Exception {
+    public List<RadiometricTarget> create(List<RadiometricTarget> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<RadiometricTarget> objects) throws Exception {
+    public void delete(List<RadiometricTarget> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<RadiometricTarget> update(List<RadiometricTarget> objects) throws Exception {
+    public List<RadiometricTarget> update(List<RadiometricTarget> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public RadiometricTarget find(RadiometricTarget object) throws Exception {
+    public RadiometricTarget find(RadiometricTarget object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public RadiometricTarget findById(String id) throws Exception {
+    public RadiometricTarget findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<RadiometricTarget> objects) throws DAODataErrorAggregateException {
+    public void validate(List<RadiometricTarget> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ScientificObjectDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/ScientificObjectDAOSesame.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -794,32 +795,32 @@ public class ScientificObjectDAOSesame extends DAOSesame<ScientificObject> {
     }
 
     @Override
-    public List<ScientificObject> create(List<ScientificObject> objects) throws Exception {
+    public List<ScientificObject> create(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<ScientificObject> objects) throws Exception {
+    public void delete(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<ScientificObject> update(List<ScientificObject> objects) throws Exception {
+    public List<ScientificObject> update(List<ScientificObject> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ScientificObject find(ScientificObject object) throws Exception {
+    public ScientificObject find(ScientificObject object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public ScientificObject findById(String id) throws Exception {
+    public ScientificObject findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<ScientificObject> objects) throws DAODataErrorAggregateException {
+    public void validate(List<ScientificObject> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SensorDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SensorDAOSesame.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -996,32 +997,32 @@ public class SensorDAOSesame extends DAOSesame<Sensor> {
     }
 
     @Override
-    public List<Sensor> create(List<Sensor> objects) throws Exception {
+    public List<Sensor> create(List<Sensor> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Sensor> objects) throws Exception {
+    public void delete(List<Sensor> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Sensor> update(List<Sensor> objects) throws Exception {
+    public List<Sensor> update(List<Sensor> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Sensor find(Sensor object) throws Exception {
+    public Sensor find(Sensor object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Sensor findById(String id) throws Exception {
+    public Sensor findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Sensor> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Sensor> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SensorProfileDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SensorProfileDAOSesame.java
@@ -14,6 +14,7 @@ package phis2ws.service.dao.sesame;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -311,27 +312,27 @@ public class SensorProfileDAOSesame extends DAOSesame<SensorProfile> {
     }
 
     @Override
-    public void delete(List<SensorProfile> objects) throws Exception {
+    public void delete(List<SensorProfile> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<SensorProfile> update(List<SensorProfile> objects) throws Exception {
+    public List<SensorProfile> update(List<SensorProfile> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public SensorProfile find(SensorProfile object) throws Exception {
+    public SensorProfile find(SensorProfile object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public SensorProfile findById(String id) throws Exception {
+    public SensorProfile findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<SensorProfile> objects) throws DAODataErrorAggregateException {
+    public void validate(List<SensorProfile> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SpeciesDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/SpeciesDAOSesame.java
@@ -10,6 +10,7 @@ package phis2ws.service.dao.sesame;
 import java.util.ArrayList;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -177,32 +178,32 @@ public class SpeciesDAOSesame extends DAOSesame<Species> {
     }
 
     @Override
-    public List<Species> create(List<Species> objects) throws Exception {
+    public List<Species> create(List<Species> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Species> objects) throws Exception {
+    public void delete(List<Species> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Species> update(List<Species> objects) throws Exception {
+    public List<Species> update(List<Species> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Species find(Species object) throws Exception {
+    public Species find(Species object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Species findById(String id) throws Exception {
+    public Species findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Species> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Species> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TimeDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TimeDAOSesame.java
@@ -9,6 +9,7 @@ package phis2ws.service.dao.sesame;
 
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
@@ -158,32 +159,32 @@ public class TimeDAOSesame extends DAOSesame<Time> {
     }
 
     @Override
-    public List<Time> create(List<Time> objects) throws Exception {
+    public List<Time> create(List<Time> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Time> objects) throws Exception {
+    public void delete(List<Time> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Time> update(List<Time> objects) throws Exception {
+    public List<Time> update(List<Time> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Time find(Time object) throws Exception {
+    public Time find(Time object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Time findById(String id) throws Exception {
+    public Time findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Time> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Time> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TraitDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TraitDaoSesame.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -528,32 +529,32 @@ public class TraitDaoSesame extends DAOSesame<Trait> {
     } 
 
     @Override
-    public List<Trait> create(List<Trait> objects) throws Exception {
+    public List<Trait> create(List<Trait> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Trait> objects) throws Exception {
+    public void delete(List<Trait> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Trait> update(List<Trait> objects) throws Exception {
+    public List<Trait> update(List<Trait> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Trait find(Trait object) throws Exception {
+    public Trait find(Trait object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Trait findById(String id) throws Exception {
+    public Trait findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Trait> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Trait> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TripletDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/TripletDAOSesame.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -390,32 +391,32 @@ public class TripletDAOSesame extends DAOSesame<Triplet> {
     }
 
     @Override
-    public List<Triplet> create(List<Triplet> objects) throws Exception {
+    public List<Triplet> create(List<Triplet> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Triplet> objects) throws Exception {
+    public void delete(List<Triplet> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Triplet> update(List<Triplet> objects) throws Exception {
+    public List<Triplet> update(List<Triplet> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Triplet find(Triplet object) throws Exception {
+    public Triplet find(Triplet object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Triplet findById(String id) throws Exception {
+    public Triplet findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Triplet> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Triplet> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/UnitDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/UnitDaoSesame.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -487,32 +488,32 @@ public class UnitDaoSesame extends DAOSesame<Unit> {
     }
 
     @Override
-    public List<Unit> create(List<Unit> objects) throws Exception {
+    public List<Unit> create(List<Unit> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Unit> objects) throws Exception {
+    public void delete(List<Unit> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Unit> update(List<Unit> objects) throws Exception {
+    public List<Unit> update(List<Unit> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Unit find(Unit object) throws Exception {
+    public Unit find(Unit object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Unit findById(String id) throws Exception {
+    public Unit findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Unit> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Unit> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/UriDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/UriDaoSesame.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -698,32 +699,32 @@ public class UriDaoSesame extends DAOSesame<Uri> {
     }
 
     @Override
-    public List<Uri> create(List<Uri> objects) throws Exception {
+    public List<Uri> create(List<Uri> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Uri> objects) throws Exception {
+    public void delete(List<Uri> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Uri> update(List<Uri> objects) throws Exception {
+    public List<Uri> update(List<Uri> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Uri find(Uri object) throws Exception {
+    public Uri find(Uri object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Uri findById(String id) throws Exception {
+    public Uri findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Uri> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Uri> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VariableDaoSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VariableDaoSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -742,32 +743,32 @@ public class VariableDaoSesame extends DAOSesame<Variable> {
     }
 
     @Override
-    public List<Variable> create(List<Variable> objects) throws Exception {
+    public List<Variable> create(List<Variable> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Variable> objects) throws Exception {
+    public void delete(List<Variable> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Variable> update(List<Variable> objects) throws Exception {
+    public List<Variable> update(List<Variable> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Variable find(Variable object) throws Exception {
+    public Variable find(Variable object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Variable findById(String id) throws Exception {
+    public Variable findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Variable> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Variable> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VectorDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VectorDAOSesame.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -819,32 +820,32 @@ public class VectorDAOSesame extends DAOSesame<Vector> {
     }
 
     @Override
-    public List<Vector> create(List<Vector> objects) throws Exception {
+    public List<Vector> create(List<Vector> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<Vector> objects) throws Exception {
+    public void delete(List<Vector> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<Vector> update(List<Vector> objects) throws Exception {
+    public List<Vector> update(List<Vector> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Vector find(Vector object) throws Exception {
+    public Vector find(Vector object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public Vector findById(String id) throws Exception {
+    public Vector findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<Vector> objects) throws DAODataErrorAggregateException {
+    public void validate(List<Vector> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VocabularyDAOSesame.java
+++ b/phis2-ws/src/main/java/phis2ws/service/dao/sesame/VocabularyDAOSesame.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import opensilex.service.dao.exception.DAODataErrorAggregateException;
+import opensilex.service.dao.exception.DAOPersistenceException;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -234,32 +235,32 @@ public class VocabularyDAOSesame extends DAOSesame<PropertyVocabularyDTO> {
     }
 
     @Override
-    public List<PropertyVocabularyDTO> create(List<PropertyVocabularyDTO> objects) throws Exception {
+    public List<PropertyVocabularyDTO> create(List<PropertyVocabularyDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void delete(List<PropertyVocabularyDTO> objects) throws Exception {
+    public void delete(List<PropertyVocabularyDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public List<PropertyVocabularyDTO> update(List<PropertyVocabularyDTO> objects) throws Exception {
+    public List<PropertyVocabularyDTO> update(List<PropertyVocabularyDTO> objects) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public PropertyVocabularyDTO find(PropertyVocabularyDTO object) throws Exception {
+    public PropertyVocabularyDTO find(PropertyVocabularyDTO object) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public PropertyVocabularyDTO findById(String id) throws Exception {
+    public PropertyVocabularyDTO findById(String id) throws DAOPersistenceException, Exception {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void validate(List<PropertyVocabularyDTO> objects) throws DAODataErrorAggregateException {
+    public void validate(List<PropertyVocabularyDTO> objects) throws DAOPersistenceException, DAODataErrorAggregateException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }


### PR DESCRIPTION
Add query exceptions in the list of exception thrown by DAO basic functions (validate, create, update, delete etc.).

Storage specific exceptions like QueryEvaluationException, RepositoryException, MalformedQueryException, QueryEvaluationException etc. will be catched and handled by the DAO classes: the DAO will log the error and then throw a generic DAOPersistenceException to the service with a message to help the understanding of the error.

Storage specific exceptions mustn't directly be thrown to the resource service classes because the services aren't supposed to know anything about the storage technology. That's why we'll use a generic DAOPersistenceException class.