### PR TITLE
Fix scientific objects label filter

### DIFF
--- a/phis2-ws/src/main/java/opensilex/service/dao/ScientificObjectRdf4jDAO.java
+++ b/phis2-ws/src/main/java/opensilex/service/dao/ScientificObjectRdf4jDAO.java
@@ -608,7 +608,7 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
      */
     public ArrayList<ScientificObject> find(Integer page, Integer pageSize, String uri, String rdfType, String experiment, String alias) {
         try {
-            SPARQLQueryBuilder sparqlQuery = prepareSearchQuery(uri, rdfType, experiment, alias);
+            SPARQLQueryBuilder sparqlQuery = prepareSearchQuery(false, page, pageSize, uri, rdfType, experiment, alias);
             //SILEX:test
             //For pool connection issues
             rep = new HTTPRepository(SESAME_SERVER, REPOSITORY_ID);
@@ -689,10 +689,13 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
 
     /**
      * Generates a query to search scientific objects by the given search params.
+     * @param page
+     * @param pageSize
      * @param uri
      * @param rdfType
      * @param experiment
      * @param alias
+     * @param count true if the query will be used to count number of scientific objects corresponding to the search result. False if not.
      * @example 
      * SELECT DISTINCT  ?uri ?alias ?experiment  ?rdfType 
      * WHERE {
@@ -707,7 +710,7 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
      * }
      * @return the generated query
      */
-    protected SPARQLQueryBuilder prepareSearchQuery(String uri, String rdfType, String experiment, String alias) {    
+    protected SPARQLQueryBuilder prepareSearchQuery(boolean count, Integer page, Integer pageSize, String uri, String rdfType, String experiment, String alias) {    
         SPARQLQueryBuilder sparqlQuery = new SPARQLQueryBuilder();
         
         sparqlQuery.appendDistinct(true);
@@ -720,7 +723,7 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
 
         //Label filter
         sparqlQuery.appendSelect("?" + ALIAS);
-        if (alias == null) {
+        if (alias == null && !count) {
             sparqlQuery.beginBodyOptional();
             sparqlQuery.appendToBody("?" + URI + " <" + Rdfs.RELATION_LABEL.toString() + "> " + "?" + ALIAS + " . ");
             sparqlQuery.endBodyOptional();
@@ -749,8 +752,10 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
                     Oeso.CONCEPT_SCIENTIFIC_OBJECT.toString(), null);
         }
         
-        sparqlQuery.appendLimit(this.getPageSize());
-        sparqlQuery.appendOffset(this.getPage() * this.getPageSize());
+        if (page != null && pageSize != null) {
+            sparqlQuery.appendLimit(pageSize);
+            sparqlQuery.appendOffset(page * pageSize);
+        }
         
         LOGGER.debug(SPARQL_QUERY + sparqlQuery.toString());
         
@@ -1226,7 +1231,7 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
      * }
      */
     private SPARQLQueryBuilder prepareCount(String uri, String rdfType, String experimentURI, String alias) {
-        SPARQLQueryBuilder query = prepareSearchQuery(uri, rdfType, experimentURI, alias);
+        SPARQLQueryBuilder query = prepareSearchQuery(true, null, null, uri, rdfType, experimentURI, alias);
         query.clearSelect();
         query.clearLimit();
         query.clearOffset();

--- a/phis2-ws/src/main/java/opensilex/service/dao/ScientificObjectRdf4jDAO.java
+++ b/phis2-ws/src/main/java/opensilex/service/dao/ScientificObjectRdf4jDAO.java
@@ -727,7 +727,7 @@ public class ScientificObjectRdf4jDAO extends Rdf4jDAO<ScientificObject> {
             sparqlQuery.beginBodyOptional();
             sparqlQuery.appendToBody("?" + URI + " <" + Rdfs.RELATION_LABEL.toString() + "> " + "?" + ALIAS + " . ");
             sparqlQuery.endBodyOptional();
-        } else {
+        } else if(alias != null){
             sparqlQuery.appendTriplet("?" + URI, Rdfs.RELATION_LABEL.toString(), "?" + ALIAS, null);
             sparqlQuery.appendAndFilter("REGEX ( str(?" + ALIAS + "),\".*" + alias + ".*\",\"i\")");
         }

--- a/phis2-ws/src/main/java/opensilex/service/resource/ScientificObjectResourceService.java
+++ b/phis2-ws/src/main/java/opensilex/service/resource/ScientificObjectResourceService.java
@@ -258,6 +258,8 @@ public class ScientificObjectResourceService extends ResourceService {
         @ApiParam(value = "Search by rdfType", example = DocumentationAnnotation.EXAMPLE_SCIENTIFIC_OBJECT_TYPE) @QueryParam("rdfType") @URL String rdfType
     ) {
         ArrayList<ScientificObjectDTO> scientificObjectsToReturn = new ArrayList<>();
+        ArrayList<ScientificObject> scientificObjects = new ArrayList<>();
+        
         ArrayList<Status> statusList = new ArrayList<>();
         ResultForm<ScientificObjectDTO> getResponse;
         
@@ -269,9 +271,12 @@ public class ScientificObjectResourceService extends ResourceService {
         //1. Get count
         Integer totalCount = scientificObjectDaoSesame.count(uri, rdfType, experimentURI, alias);
         
-        //2. Get list of scientific objects
-        ArrayList<ScientificObject> scientificObjects = scientificObjectDaoSesame.find(page, pageSize, uri, rdfType, experimentURI, alias);
-        
+        // If scientific objects found
+        if(totalCount > 0){
+            //2. Get list of scientific objects
+            scientificObjects = scientificObjectDaoSesame.find(page, pageSize, uri, rdfType, experimentURI, alias);
+        }
+
         if (scientificObjects == null) { //Request failure
             getResponse = new ResultForm<>(0, 0, scientificObjectsToReturn, true);
             return noResultFound(getResponse, statusList);


### PR DESCRIPTION
- Fix query result when filtering by object alias
- Execute only one query when the number of results is equal to 0