### PR TITLE
Use HTTPS for repo.spring.io

### DIFF
--- a/phis2-ws/pom.xml
+++ b/phis2-ws/pom.xml
@@ -18,7 +18,7 @@
         <!--REPO CRYPTAGE-->
         <repository>
             <id>spring-milestones</id>
-            <url>http://repo.spring.io/libs-milestone/</url>
+            <url>https://repo.spring.io/libs-milestone/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
See: https://spring.io/blog/2019/09/16/goodbye-http-repo-spring-use-https

HTTP is no longer supported for repo.spring.io